### PR TITLE
chat: Vencord Discord (nixcord) with ad/telemetry blocking

### DIFF
--- a/apps/chat.nix
+++ b/apps/chat.nix
@@ -1,3 +1,4 @@
+{ inputs, ... }:
 let
   tags = [ "chat" ];
 in {
@@ -8,8 +9,10 @@ in {
       packages = [ "element-desktop" ];
     }
     {
+      # Discord on Linux is provided by the nixcord app below (Vencord-patched).
+      # Darwin keeps the plain upstream package.
       inherit tags;
-      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      systems = [ "x86_64-darwin" "aarch64-darwin" ];
       packages = [ "discord" ];
     }
     {
@@ -28,8 +31,70 @@ in {
     slack = {
       nixpkgs.packages.unfree = [ "slack" ];
     };
-    discord = {
+
+    # NB: this app is named `nixcord`, not `discord`. An app whose name matches
+    # its package (`discord`) does not get its home module applied to NixOS
+    # hosts under this framework; a distinct name works correctly.
+    nixcord = {
+      inherit tags;
       nixpkgs.packages.unfree = [ "discord" ];
+
+      # Vencord-patched Discord, configured declaratively. NOTE: because config
+      # is declarative, Vencord's in-app plugin menu will NOT persist changes —
+      # enable plugins here instead.
+      home = { ... }: {
+        imports = [ inputs.nixcord.homeModules.nixcord ];
+
+        programs.nixcord = {
+          enable = true;
+          discord.vencord.enable = true;
+
+          # Hide the Nitro/boost upsell UI via CSS. CSS is version-proof (unlike
+          # plugin keys, a bad selector just does nothing rather than erroring).
+          quickCss = ''
+            /* Hide Nitro upsell entry in the user settings / gift buttons */
+            [class*="premiumUpsell"],
+            [class*="nitroUpsell"],
+            [aria-label*="Nitro" i][class*="button"],
+            [class*="buyButton"] {
+              display: none !important;
+            }
+          '';
+
+          config = {
+            useQuickCss = true;
+
+            plugins = {
+              # TODO(chadac): add the exact Vencord plugin keys you confirm from
+              # the in-app plugin list, e.g.:
+              #   disableQuestButton.enable = true;   # quest popups
+              #   noDevtoolsWarning.enable  = true;   # console "HOLD UP" banner
+              # Left empty for now so the first build can't fail on an unknown
+              # plugin name.
+            };
+          };
+        };
+      };
+
+      # Network-level blocking: Discord telemetry + common ad / YouTube-embed ad
+      # hosts. This is a coarse net (helps with telemetry and some embedded-video
+      # ads); full YouTube ad-blocking still needs uBlock Origin in a browser.
+      nixos = {
+        # Only whole hostnames work in /etc/hosts (not URL paths, so Discord's
+        # own /api/science telemetry endpoint can't be blocked here without
+        # breaking discord.com — that one needs a Vencord plugin instead).
+        networking.extraHosts = ''
+          # --- Discord telemetry (dedicated analytics hosts, safe to null) ---
+          0.0.0.0 discord-analytics.com
+          0.0.0.0 discordapp.io
+          # --- generic ad / tracking (helps with some YouTube-embed ads) ---
+          0.0.0.0 doubleclick.net
+          0.0.0.0 static.doubleclick.net
+          0.0.0.0 googleads.g.doubleclick.net
+          0.0.0.0 pagead2.googlesyndication.com
+          0.0.0.0 ad.doubleclick.net
+        '';
+      };
     };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -224,6 +224,24 @@
         "type": "github"
       }
     },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -410,6 +428,29 @@
         "type": "github"
       }
     },
+    "nixcord": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-nixcord": "nixpkgs-nixcord",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1785840384,
+        "narHash": "sha256-flAhSIdh6FbpQ7PZTWDzfskCgMBBqRMR9EFNiQjLbAY=",
+        "owner": "4evy",
+        "repo": "nixcord",
+        "rev": "c2d7410937e517e4d40fe0fd9a3873a8d08a249b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "4evy",
+        "repo": "nixcord",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782767157,
@@ -469,6 +510,37 @@
         "dir": "lib",
         "owner": "NixOS",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_3": {
+      "locked": {
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-nixcord": {
+      "locked": {
+        "lastModified": 1785386831,
+        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -591,7 +663,7 @@
           "nixpkgs"
         ],
         "systems": "systems_4",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1743690424,
@@ -619,6 +691,7 @@
         "mise": "mise",
         "nix-config-modules": "nix-config-modules",
         "nix-darwin": "nix-darwin",
+        "nixcord": "nixcord",
         "nixpkgs": "nixpkgs_6",
         "poetry2nix": "poetry2nix",
         "zsh-256color": "zsh-256color"
@@ -702,6 +775,27 @@
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixcord",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785360170,
+        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "poetry2nix",

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,12 @@
       url = "github:nix-community/emacs-overlay";
     };
 
+    # nixcord - declarative Vencord-patched Discord
+    nixcord = {
+      url = "github:4evy/nixcord";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # for building poetry packages
     poetry2nix = {
       url = "github:nix-community/poetry2nix";


### PR DESCRIPTION
Replaces plain Discord on Linux with a **Vencord-patched** Discord managed declaratively via [nixcord](https://github.com/4evy/nixcord), to strip Nitro upsells / quest nags and cut telemetry.

## Changes
- **flake input**: add `nixcord` (`github:4evy/nixcord`, `nixpkgs.follows`).
- **apps/chat.nix**:
  - Linux Discord now comes from the `nixcord` app (Vencord). Darwin keeps the plain `discord` package.
  - `quickCss` hides the Nitro/boost upsell UI (CSS is version-proof — a bad selector no-ops instead of failing eval).
  - NixOS `networking.extraHosts` blocklist for Discord telemetry + common ad/YouTube-embed ad domains.

## Notes / caveats
- **App is named `nixcord`, not `discord`, on purpose.** An app whose name matches its package (`discord`) does **not** get its home module applied to NixOS hosts under nix-config-modules (verified empirically — a differently-named app works). Documented inline.
- **Vencord plugins are a TODO.** The declarative config means the in-app plugin menu won't persist, and an unknown plugin key fails eval — so I left `config.plugins` empty with a marked spot. After launching this once, confirm the exact keys (e.g. `disableQuestButton`, `noDevtoolsWarning`) from Vencord's plugin list and drop them in.
- **YouTube ad embeds inside Discord**: the hosts blocklist helps partially; full YouTube ad-blocking still needs uBlock Origin in a real browser (Discord's embedded player can't be reached by it).

## Validation
- `homeConfigurations.odin` **builds** and contains the Vencord Discord.
- `homeConfigurations.odin-darwin` keeps plain discord (nixcord correctly scoped).
- `nixosConfigurations.odin` evaluates with the extraHosts blocklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)